### PR TITLE
refactor: Simplify `ext`: remove convention string, always use unma...

### DIFF
--- a/include/compiler/ast.h
+++ b/include/compiler/ast.h
@@ -118,9 +118,7 @@ struct AstNode
         // external statement
         struct
         {
-            char    *name;       // function name in Mach code
-            char    *convention; // calling convention (e.g., "C")
-            char    *symbol;     // target symbol name (default: same as name)
+            char    *name; // function name (also used as linker symbol)
             AstNode *type;
             bool     is_public;
         } ext_stmt;

--- a/src/compiler/ast.c
+++ b/src/compiler/ast.c
@@ -49,8 +49,6 @@ void ast_node_dnit(AstNode *node)
 
     case AST_STMT_EXT:
         free(node->ext_stmt.name);
-        free(node->ext_stmt.convention);
-        free(node->ext_stmt.symbol);
         if (node->ext_stmt.type)
         {
             ast_node_dnit(node->ext_stmt.type);
@@ -625,11 +623,9 @@ static AstNode *ast_clone_checked(const AstNode *node)
         break;
 
     case AST_STMT_EXT:
-        clone->ext_stmt.name            = ast_strdup(node->ext_stmt.name);
-        clone->ext_stmt.convention      = ast_strdup(node->ext_stmt.convention);
-        clone->ext_stmt.symbol          = ast_strdup(node->ext_stmt.symbol);
-        clone->ext_stmt.type            = ast_clone_checked(node->ext_stmt.type);
-        clone->ext_stmt.is_public       = node->ext_stmt.is_public;
+        clone->ext_stmt.name      = ast_strdup(node->ext_stmt.name);
+        clone->ext_stmt.type      = ast_clone_checked(node->ext_stmt.type);
+        clone->ext_stmt.is_public = node->ext_stmt.is_public;
         break;
 
     case AST_STMT_FWD:

--- a/src/compiler/masm/lower.c
+++ b/src/compiler/masm/lower.c
@@ -1318,7 +1318,20 @@ static MasmOperand lower_call_with_sret(Masm *masm, MasmSection *text, AstNode *
             }
             else
             {
-                target = masm_operand_label(func->ident_expr.name);
+                const char *call_name = func->ident_expr.name;
+                if (ctx->symbols)
+                {
+                    Symbol *resolved = symbol_table_lookup(ctx->symbols, call_name);
+                    if (resolved)
+                    {
+                        const char *link = symbol_linkage_name(resolved);
+                        if (link)
+                        {
+                            call_name = link;
+                        }
+                    }
+                }
+                target = masm_operand_label(call_name);
             }
         }
     }

--- a/src/compiler/parser.c
+++ b/src/compiler/parser.c
@@ -1333,72 +1333,9 @@ AstNode *parser_parse_stmt_ext(Parser *parser, bool is_public)
         return NULL;
     }
 
-    // initialize fields
-    node->ext_stmt.name       = NULL;
-    node->ext_stmt.convention = NULL;
-    node->ext_stmt.symbol     = NULL;
-    node->ext_stmt.type       = NULL;
-    node->ext_stmt.is_public  = is_public;
-
-    // check for optional calling convention/symbol specification
-    if (parser_match(parser, TOKEN_LIT_STRING))
-    {
-        char *raw = lexer_raw_value(parser->lexer, parser->previous);
-        if (!raw)
-        {
-            parser_report_alloc_failure(parser, "out of memory reading extern metadata");
-            parser_free_node(node);
-            return NULL;
-        }
-
-        size_t raw_len   = strlen(raw);
-        size_t copy_len  = raw_len >= 2 ? raw_len - 2 : 0; // remove quotes safely
-        char  *conv_spec = malloc(copy_len + 1);
-        if (!conv_spec)
-        {
-            free(raw);
-            parser_report_alloc_failure(parser, "out of memory parsing extern metadata");
-            parser_free_node(node);
-            return NULL;
-        }
-
-        memcpy(conv_spec, raw + 1, copy_len);
-        conv_spec[copy_len] = '\0';
-        free(raw);
-
-        // parse "convention:symbol" or just "convention"
-        char *colon = strchr(conv_spec, ':');
-        if (colon)
-        {
-            *colon                    = '\0';
-            node->ext_stmt.convention = parser_strdup_checked(parser, conv_spec, "out of memory duplicating convention");
-            if (!node->ext_stmt.convention)
-            {
-                free(conv_spec);
-                parser_free_node(node);
-                return NULL;
-            }
-            node->ext_stmt.symbol = parser_strdup_checked(parser, colon + 1, "out of memory duplicating external symbol");
-            if (!node->ext_stmt.symbol)
-            {
-                free(conv_spec);
-                parser_free_node(node);
-                return NULL;
-            }
-        }
-        else
-        {
-            node->ext_stmt.convention = parser_strdup_checked(parser, conv_spec, "out of memory duplicating convention");
-            if (!node->ext_stmt.convention)
-            {
-                free(conv_spec);
-                parser_free_node(node);
-                return NULL;
-            }
-        }
-
-        free(conv_spec);
-    }
+    node->ext_stmt.name      = NULL;
+    node->ext_stmt.type      = NULL;
+    node->ext_stmt.is_public = is_public;
 
     node->ext_stmt.name = parser_parse_identifier(parser);
     if (!node->ext_stmt.name)
@@ -1406,28 +1343,6 @@ AstNode *parser_parse_stmt_ext(Parser *parser, bool is_public)
         parser_error_at_current(parser, "expected identifier after 'ext'");
         parser_free_node(node);
         return NULL;
-    }
-
-    // if no symbol specified, use the function name
-    if (!node->ext_stmt.symbol)
-    {
-        node->ext_stmt.symbol = parser_strdup_checked(parser, node->ext_stmt.name, "out of memory duplicating external symbol");
-        if (!node->ext_stmt.symbol)
-        {
-            parser_free_node(node);
-            return NULL;
-        }
-    }
-
-    // if no convention specified, default to "C"
-    if (!node->ext_stmt.convention)
-    {
-        node->ext_stmt.convention = parser_strdup_checked(parser, "C", "out of memory duplicating convention");
-        if (!node->ext_stmt.convention)
-        {
-            parser_free_node(node);
-            return NULL;
-        }
     }
 
     if (!parser_consume(parser, TOKEN_COLON, "expected ':' after external name"))

--- a/src/compiler/sema.c
+++ b/src/compiler/sema.c
@@ -1316,10 +1316,10 @@ static int sema_collect_symbols(Sema *sema, AstNode *node)
         return sema_collect_def_symbol(sema, node);
 
     case AST_STMT_EXT:
+        return sema_collect_ext_symbol(sema, node);
 
     case AST_STMT_FWD:
         return sema_collect_fwd_symbol(sema, node);
-        return sema_collect_ext_symbol(sema, node);
 
     case AST_STMT_VAL:
     case AST_STMT_VAR:
@@ -1460,16 +1460,12 @@ static int sema_analyze_ext(Sema *sema, AstNode *node)
     sym->type  = t;
     node->type = t;
 
-    // set linkage/export name to the underlying symbol name
-    if (node->ext_stmt.symbol)
+    // ext symbols are never mangled — use the name as-is for linkage.
+    // only set if not already overridden by $name.symbol annotation.
+    if (!sym->export_name)
     {
-        if (sym->export_name)
-        {
-            free(sym->export_name);
-        }
-        sym->export_name = strdup(node->ext_stmt.symbol);
+        sym->export_name = strdup(node->ext_stmt.name);
     }
-
     return 0;
 }
 
@@ -2710,10 +2706,10 @@ static int sema_analyze_stmt(Sema *sema, AstNode *node)
         return sema_analyze_def(sema, node);
 
     case AST_STMT_EXT:
+        return sema_analyze_ext(sema, node);
 
     case AST_STMT_FWD:
         return sema_analyze_fwd(sema, node);
-        return sema_analyze_ext(sema, node);
 
     case AST_STMT_USE:
         return sema_analyze_use(sema, node);


### PR DESCRIPTION
Closes #26