### PR TITLE
feat: backtick zstr literals + builtin str record type

### DIFF
--- a/include/compiler/lexer.h
+++ b/include/compiler/lexer.h
@@ -29,11 +29,13 @@ Token *lexer_parse_identifier(Lexer *lexer);
 Token *lexer_parse_lit_number(Lexer *lexer);
 Token *lexer_parse_lit_char(Lexer *lexer);
 Token *lexer_parse_lit_string(Lexer *lexer);
+Token *lexer_parse_lit_zstr(Lexer *lexer);
 
 unsigned long long lexer_eval_lit_int(Lexer *lexer, Token *token);
 double             lexer_eval_lit_float(Lexer *lexer, Token *token);
 char               lexer_eval_lit_char(Lexer *lexer, Token *token);
 char              *lexer_eval_lit_string(Lexer *lexer, Token *token);
+char              *lexer_eval_lit_zstr(Lexer *lexer, Token *token);
 char              *lexer_raw_value(Lexer *lexer, Token *token);
 
 Token *lexer_emit(Lexer *lexer, TokenKind kind, int len);

--- a/include/compiler/token.h
+++ b/include/compiler/token.h
@@ -12,6 +12,7 @@ typedef enum TokenKind
     TOKEN_LIT_FLOAT,
     TOKEN_LIT_CHAR,
     TOKEN_LIT_STRING,
+    TOKEN_LIT_ZSTR,
 
     TOKEN_IDENTIFIER,
 

--- a/include/compiler/type.h
+++ b/include/compiler/type.h
@@ -131,4 +131,12 @@ int type_mangle(Type *type, char *buffer, size_t buffer_size);
 //   ptr reg_save_area;
 Type *type_get_builtin_va_list(void);
 
+// str: the type of double-quoted string literals.
+// the only complex (non-primitive) builtin type in mach; the language has it
+// because string literals are syntax that must produce a typed value, and that
+// value is record-shaped.
+//   u32  len;
+//   *u8  data;
+Type *type_get_builtin_str(void);
+
 #endif // TYPE_H

--- a/src/compiler/ast.c
+++ b/src/compiler/ast.c
@@ -389,7 +389,7 @@ void ast_node_dnit(AstNode *node)
         break;
 
     case AST_EXPR_LIT:
-        if (node->lit_expr.kind == TOKEN_LIT_STRING)
+        if (node->lit_expr.kind == TOKEN_LIT_STRING || node->lit_expr.kind == TOKEN_LIT_ZSTR)
         {
             free(node->lit_expr.string_val);
         }
@@ -830,6 +830,7 @@ static AstNode *ast_clone_checked(const AstNode *node)
             clone->lit_expr.char_val = node->lit_expr.char_val;
             break;
         case TOKEN_LIT_STRING:
+        case TOKEN_LIT_ZSTR:
             clone->lit_expr.string_val = ast_strdup(node->lit_expr.string_val);
             break;
         default:
@@ -1270,6 +1271,11 @@ void ast_print(AstNode *node, int indent)
             printf("STRING \"");
             print_escaped_string(stdout, node->lit_expr.string_val);
             printf("\"\n");
+            break;
+        case TOKEN_LIT_ZSTR:
+            printf("ZSTR `");
+            print_escaped_string(stdout, node->lit_expr.string_val);
+            printf("`\n");
             break;
         default:
             printf("???\n");
@@ -1821,6 +1827,11 @@ static void ast_print_to_file(AstNode *node, FILE *file, int indent)
             fprintf(file, "STRING \"");
             print_escaped_string(file, node->lit_expr.string_val);
             fprintf(file, "\"\n");
+            break;
+        case TOKEN_LIT_ZSTR:
+            fprintf(file, "ZSTR `");
+            print_escaped_string(file, node->lit_expr.string_val);
+            fprintf(file, "`\n");
             break;
         default:
             fprintf(file, "???\n");

--- a/src/compiler/lexer.c
+++ b/src/compiler/lexer.c
@@ -446,6 +446,77 @@ Token *lexer_parse_lit_string(Lexer *lexer)
     return string_token;
 }
 
+// zero-terminated string formatting rules:
+// - must be surrounded by backticks
+// - any character is allowed
+// the following escape sequences are allowed:
+// - `\'` for single quote
+// - `\"` for double quote
+// - `\\` for backslash
+// - `\`` for backtick
+// - `\n` for newline
+// - `\t` for tab
+// - `\r` for carriage return
+// - `\0` for null
+Token *lexer_parse_lit_zstr(Lexer *lexer)
+{
+    int start = lexer->pos;
+
+    if (lexer_current(lexer) != '`')
+    {
+        Token *error_token = malloc(sizeof(Token));
+        token_init(error_token, TOKEN_ERROR, start, 1);
+        return error_token;
+    }
+
+    lexer_advance(lexer);
+
+    while (!lexer_at_end(lexer) && lexer_current(lexer) != '`')
+    {
+        if (lexer_current(lexer) == '\\')
+        {
+            lexer_advance(lexer);
+
+            Token *error_token;
+
+            switch (lexer_current(lexer))
+            {
+            case '\'':
+            case '\"':
+            case '\\':
+            case '`':
+            case 'n':
+            case 't':
+            case 'r':
+            case '0':
+                lexer_advance(lexer);
+                break;
+            default:
+                error_token = malloc(sizeof(Token));
+                token_init(error_token, TOKEN_ERROR, start, lexer->pos - start);
+                return error_token;
+            }
+        }
+        else
+        {
+            lexer_advance(lexer);
+        }
+    }
+
+    if (lexer_at_end(lexer) || lexer_current(lexer) != '`')
+    {
+        Token *error_token = malloc(sizeof(Token));
+        token_init(error_token, TOKEN_ERROR, start, lexer->pos - start);
+        return error_token;
+    }
+
+    lexer_advance(lexer);
+
+    Token *zstr_token = malloc(sizeof(Token));
+    token_init(zstr_token, TOKEN_LIT_ZSTR, start, lexer->pos - start);
+    return zstr_token;
+}
+
 unsigned long long lexer_eval_lit_int(Lexer *lexer, Token *token)
 {
     int   base = 10;
@@ -605,6 +676,64 @@ char *lexer_eval_lit_string(Lexer *lexer, Token *token)
     return value;
 }
 
+char *lexer_eval_lit_zstr(Lexer *lexer, Token *token)
+{
+    int   src_len = token->len - 2; // inside backticks
+    char *value   = malloc((size_t)src_len + 1);
+    if (!value)
+    {
+        return NULL;
+    }
+
+    int j = 0;
+    for (int i = 0; i < src_len; i++)
+    {
+        char c = lexer->source[token->pos + 1 + i];
+        if (c == '\\' && i + 1 < src_len)
+        {
+            char e = lexer->source[token->pos + 1 + i + 1];
+            switch (e)
+            {
+            case '\'':
+                value[j++] = '\'';
+                break;
+            case '"':
+                value[j++] = '"';
+                break;
+            case '\\':
+                value[j++] = '\\';
+                break;
+            case '`':
+                value[j++] = '`';
+                break;
+            case 'n':
+                value[j++] = '\n';
+                break;
+            case 't':
+                value[j++] = '\t';
+                break;
+            case 'r':
+                value[j++] = '\r';
+                break;
+            case '0':
+                value[j++] = '\0';
+                break;
+            default:
+                // unknown escape: preserve as-is (common behavior)
+                value[j++] = e;
+                break;
+            }
+            i++; // skip the escaped character
+        }
+        else
+        {
+            value[j++] = c;
+        }
+    }
+    value[j] = '\0';
+    return value;
+}
+
 char *lexer_raw_value(Lexer *lexer, Token *token)
 {
     char *value = calloc(token->len + 1, sizeof(char));
@@ -649,6 +778,8 @@ Token *lexer_next(Lexer *lexer)
         return lexer_parse_lit_char(lexer);
     case '\"':
         return lexer_parse_lit_string(lexer);
+    case '`':
+        return lexer_parse_lit_zstr(lexer);
     case '(':
         return lexer_emit(lexer, TOKEN_L_PAREN, 1);
     case ')':

--- a/src/compiler/masm/lower.c
+++ b/src/compiler/masm/lower.c
@@ -1708,7 +1708,7 @@ static MasmOperand lower_expr(Masm *masm, MasmSection *text, AstNode *expr, Lowe
             memcpy(&bits, &fval, sizeof(bits));
             return masm_operand_imm((int64_t)bits);
         }
-        else if (expr->lit_expr.kind == TOKEN_LIT_STRING)
+        else if (expr->lit_expr.kind == TOKEN_LIT_STRING || expr->lit_expr.kind == TOKEN_LIT_ZSTR)
         {
 #ifdef MASM_DEBUG
             fprintf(stderr, "[lower_expr] string literal '%s', text=%p, inst_count before=%zu\n", expr->lit_expr.string_val, (void *)text, text->inst_count);
@@ -4290,7 +4290,7 @@ static void emit_global_data(Masm *masm, MasmSection *section, AstNode *expr, si
                 masm_section_append_zero(section, size - 8);
             }
         }
-        else if (expr->lit_expr.kind == TOKEN_LIT_STRING)
+        else if (expr->lit_expr.kind == TOKEN_LIT_STRING || expr->lit_expr.kind == TOKEN_LIT_ZSTR)
         {
             // String literal: emit the string to .rodata and store a pointer relocation
             const char *str_val = expr->lit_expr.string_val;

--- a/src/compiler/masm/lower.c
+++ b/src/compiler/masm/lower.c
@@ -1710,36 +1710,67 @@ static MasmOperand lower_expr(Masm *masm, MasmSection *text, AstNode *expr, Lowe
         }
         else if (expr->lit_expr.kind == TOKEN_LIT_STRING || expr->lit_expr.kind == TOKEN_LIT_ZSTR)
         {
-#ifdef MASM_DEBUG
-            fprintf(stderr, "[lower_expr] string literal '%s', text=%p, inst_count before=%zu\n", expr->lit_expr.string_val, (void *)text, text->inst_count);
-#endif
-            // Create unique label
-            char label[32];
-            snprintf(label, sizeof(label), ".Lstr_%d", (*ctx->str_counter)++);
+            const char *str_val = expr->lit_expr.string_val;
+            size_t      len     = strlen(str_val);
 
-            // Add to .rodata
+            // Create unique label for the bytes
+            char bytes_label[32];
+            snprintf(bytes_label, sizeof(bytes_label), ".Lstr_%d", (*ctx->str_counter)++);
+
             MasmSection *rodata = masm_get_or_create_section(masm, ".rodata", MASM_SECTION_RODATA);
 
-            // Add label symbol
-            MasmSymbol *sym   = masm_symbol_create(label, MASM_SYMBOL_DATA, MASM_BIND_LOCAL);
-            sym->section_name = strdup(".rodata");
-            sym->offset       = rodata->data_size;
-            size_t len        = strlen(expr->lit_expr.string_val);
-            sym->size         = len + 1;
-            masm_add_symbol(masm, sym);
+            // Append string bytes (null-terminated for cstr / ffi compatibility) to .rodata
+            MasmSymbol *bytes_sym   = masm_symbol_create(bytes_label, MASM_SYMBOL_DATA, MASM_BIND_LOCAL);
+            bytes_sym->section_name = strdup(".rodata");
+            bytes_sym->offset       = rodata->data_size;
+            bytes_sym->size         = len + 1;
+            masm_add_symbol(masm, bytes_sym);
 
-            // append string data (null-terminated) to .rodata
-            masm_section_append_data(rodata, expr->lit_expr.string_val, len);
+            masm_section_append_data(rodata, str_val, len);
             uint8_t zero = 0;
             masm_section_append_data(rodata, &zero, 1);
 
-            // MOV result, label (absolute address)
+            // For zstr (backtick literal): the result is the bare *u8 pointer
+            if (expr->lit_expr.kind == TOKEN_LIT_ZSTR)
+            {
+                MasmOperand res = isa_result(ctx, 8);
+                MasmOperand src = masm_operand_label(bytes_label);
+                masm_section_append_inst(text, masm_inst_2(MASM_IR_ADDR, res, src));
+                return res;
+            }
+
+            // For double-quoted str literal: build a 16-byte str record { u32 len, *u8 data }
+            // in .rodata and return its address (aggregate convention).
+            char rec_label[32];
+            snprintf(rec_label, sizeof(rec_label), ".Lstrrec_%d", (*ctx->str_counter)++);
+
+            // Align to 8 (str record alignment is 8 due to the *u8 field)
+            while (rodata->data_size % 8 != 0)
+            {
+                masm_section_append_zero(rodata, 1);
+            }
+
+            MasmSymbol *rec_sym   = masm_symbol_create(rec_label, MASM_SYMBOL_DATA, MASM_BIND_LOCAL);
+            rec_sym->section_name = strdup(".rodata");
+            rec_sym->offset       = rodata->data_size;
+            rec_sym->size         = 16;
+            masm_add_symbol(masm, rec_sym);
+
+            // len: u32 at offset 0
+            uint32_t len_u32 = (uint32_t)len;
+            masm_section_append_data(rodata, &len_u32, 4);
+            // 4 bytes padding so data field is 8-byte aligned
+            masm_section_append_zero(rodata, 4);
+            // data: *u8 at offset 8 — placeholder, relocated to bytes_label
+            size_t  data_field_offset = rodata->data_size;
+            uint64_t zero_ptr         = 0;
+            masm_section_append_data(rodata, &zero_ptr, 8);
+            masm_section_append_reloc(rodata, data_field_offset, bytes_label, 0);
+
+            // Return the address of the str record (aggregate-by-pointer convention)
             MasmOperand res = isa_result(ctx, 8);
-            MasmOperand src = masm_operand_label(label);
+            MasmOperand src = masm_operand_label(rec_label);
             masm_section_append_inst(text, masm_inst_2(MASM_IR_ADDR, res, src));
-#ifdef MASM_DEBUG
-            fprintf(stderr, "[lower_expr] string literal: emitted MOV, text section inst_count after=%zu\n", text->inst_count);
-#endif
             return res;
         }
     }
@@ -4292,43 +4323,55 @@ static void emit_global_data(Masm *masm, MasmSection *section, AstNode *expr, si
         }
         else if (expr->lit_expr.kind == TOKEN_LIT_STRING || expr->lit_expr.kind == TOKEN_LIT_ZSTR)
         {
-            // String literal: emit the string to .rodata and store a pointer relocation
-            const char *str_val = expr->lit_expr.string_val;
-            size_t      str_len = strlen(str_val) + 1; // include null terminator
+            // Emit the string bytes (null-terminated) to .rodata
+            const char *str_val   = expr->lit_expr.string_val;
+            size_t      bytes_len = strlen(str_val) + 1; // include null terminator
 
-            // Create unique label for the string
-            char label[64];
-            snprintf(label, sizeof(label), ".Lstr_%d", counters->str_counter++);
+            char bytes_label[64];
+            snprintf(bytes_label, sizeof(bytes_label), ".Lstr_%d", counters->str_counter++);
 
-            // Add string to .rodata
-            MasmSection *rodata = masm_get_or_create_section(masm, ".rodata", MASM_SECTION_RODATA);
+            MasmSection *rodata     = masm_get_or_create_section(masm, ".rodata", MASM_SECTION_RODATA);
+            MasmSymbol  *bytes_sym  = masm_symbol_create(bytes_label, MASM_SYMBOL_DATA, MASM_BIND_LOCAL);
+            bytes_sym->section_name = strdup(".rodata");
+            bytes_sym->offset       = rodata->data_size;
+            bytes_sym->size         = bytes_len;
+            masm_add_symbol(masm, bytes_sym);
 
-            // Create symbol for the string
-            MasmSymbol *sym   = masm_symbol_create(label, MASM_SYMBOL_DATA, MASM_BIND_LOCAL);
-            sym->section_name = strdup(".rodata");
-            sym->offset       = rodata->data_size;
-            sym->size         = str_len;
-            masm_add_symbol(masm, sym);
-
-            // Append string data to .rodata
-            masm_section_append_data(rodata, str_val, str_len - 1);
+            masm_section_append_data(rodata, str_val, bytes_len - 1);
             uint8_t zero = 0;
             masm_section_append_data(rodata, &zero, 1);
 
-            // Record the relocation offset in the data section (before appending zeros)
-            size_t reloc_offset = section->data_size;
-
-            // Emit placeholder zeros for the pointer (8 bytes for 64-bit)
-            size_t ptr_size = 8;
-            masm_section_append_zero(section, ptr_size);
-
-            // Add relocation entry pointing to the string symbol
-            masm_section_append_reloc(section, reloc_offset, label, 0);
-
-            // If size > 8, pad the rest
-            if (size > ptr_size)
+            if (expr->lit_expr.kind == TOKEN_LIT_ZSTR)
             {
-                masm_section_append_zero(section, size - ptr_size);
+                // zstr literal in data context: emit a pointer relocation directly into the
+                // surrounding aggregate field
+                size_t reloc_offset = section->data_size;
+                size_t ptr_size     = 8;
+                masm_section_append_zero(section, ptr_size);
+                masm_section_append_reloc(section, reloc_offset, bytes_label, 0);
+                if (size > ptr_size)
+                {
+                    masm_section_append_zero(section, size - ptr_size);
+                }
+            }
+            else
+            {
+                // str literal in data context: emit the 16-byte record
+                //   { u32 len; pad 4; *u8 data; }
+                // directly into the section. The data field gets a relocation to bytes_label.
+                size_t   start_offset = section->data_size;
+                uint32_t len_u32      = (uint32_t)(bytes_len - 1); // exclude null terminator from len
+                masm_section_append_data(section, &len_u32, 4);
+                masm_section_append_zero(section, 4);
+                size_t   data_field_offset = section->data_size;
+                uint64_t zero_ptr          = 0;
+                masm_section_append_data(section, &zero_ptr, 8);
+                masm_section_append_reloc(section, data_field_offset, bytes_label, 0);
+                size_t written = section->data_size - start_offset;
+                if (size > written)
+                {
+                    masm_section_append_zero(section, size - written);
+                }
             }
         }
         else

--- a/src/compiler/parser.c
+++ b/src/compiler/parser.c
@@ -2969,6 +2969,19 @@ AstNode *parser_parse_expr_atom(Parser *parser)
         return lit;
     }
 
+    case TOKEN_LIT_ZSTR:
+    {
+        AstNode *lit = parser_alloc_node(parser, AST_EXPR_LIT, parser->current);
+        if (!lit)
+        {
+            return NULL;
+        }
+        lit->lit_expr.kind       = TOKEN_LIT_ZSTR;
+        lit->lit_expr.string_val = lexer_eval_lit_zstr(parser->lexer, parser->current);
+        parser_advance(parser);
+        return lit;
+    }
+
     case TOKEN_L_PAREN:
     {
         parser_advance(parser);

--- a/src/compiler/sema.c
+++ b/src/compiler/sema.c
@@ -3018,11 +3018,11 @@ int sema_analyze_expr(Sema *sema, AstNode *node)
                 node->type = type_get_primitive(TYPE_U8);
                 break;
             case TOKEN_LIT_STRING:
-                // simplified: string is pointer to u8
-                node->type = type_create_pointer(type_get_primitive(TYPE_U8));
+                // string literals produce values of the builtin str record type
+                node->type = type_get_builtin_str();
                 break;
             case TOKEN_LIT_ZSTR:
-                // zero-terminated string literal: same lowering as string for now
+                // zero-terminated string literals produce *u8 (raw byte pointer)
                 node->type = type_create_pointer(type_get_primitive(TYPE_U8));
                 break;
             default:
@@ -4181,6 +4181,12 @@ static Type *sema_resolve_type(Sema *sema, AstNode *type_node)
         if (strcmp(name, "va_list") == 0)
         {
             return type_get_builtin_va_list();
+        }
+
+        // builtin str (the type produced by double-quoted string literals)
+        if (strcmp(name, "str") == 0)
+        {
+            return type_get_builtin_str();
         }
 
         // look up user-defined types (local scope, then imports; or alias-qualified)

--- a/src/compiler/sema.c
+++ b/src/compiler/sema.c
@@ -3021,6 +3021,10 @@ int sema_analyze_expr(Sema *sema, AstNode *node)
                 // simplified: string is pointer to u8
                 node->type = type_create_pointer(type_get_primitive(TYPE_U8));
                 break;
+            case TOKEN_LIT_ZSTR:
+                // zero-terminated string literal: same lowering as string for now
+                node->type = type_create_pointer(type_get_primitive(TYPE_U8));
+                break;
             default:
                 break;
             }

--- a/src/compiler/token.c
+++ b/src/compiler/token.c
@@ -56,6 +56,8 @@ char *token_kind_to_string(TokenKind kind)
         return "LIT_CHAR";
     case TOKEN_LIT_STRING:
         return "LIT_STRING";
+    case TOKEN_LIT_ZSTR:
+        return "LIT_ZSTR";
 
     case TOKEN_IDENTIFIER:
         return "IDENTIFIER";

--- a/src/compiler/type.c
+++ b/src/compiler/type.c
@@ -182,6 +182,33 @@ Type *type_get_builtin_va_list(void)
     return builtin_va_list_type;
 }
 
+static Type *builtin_str_type = NULL;
+
+Type *type_get_builtin_str(void)
+{
+    if (builtin_str_type)
+    {
+        return builtin_str_type;
+    }
+
+    // str: rec { len: u32; data: *u8; }
+    // produced by string literals ("..."); the only complex builtin in mach.
+    TypeField *fields = calloc(2, sizeof(TypeField));
+    if (!fields)
+    {
+        return NULL;
+    }
+
+    fields[0].name = strdup("len");
+    fields[0].type = type_get_primitive(TYPE_U32);
+
+    fields[1].name = strdup("data");
+    fields[1].type = type_create_pointer(type_get_primitive(TYPE_U8));
+
+    builtin_str_type = type_create_struct("str", NULL, fields, 2);
+    return builtin_str_type;
+}
+
 bool type_equals(Type *a, Type *b)
 {
     if (!a || !b)


### PR DESCRIPTION
## Summary

Two related changes that establish strings as a typed record:

1. **Backtick literal syntax** for zero-terminated strings: `` `foo` `` produces a `*u8` pointing at null-terminated bytes in `.rodata`. Distinct from double-quoted strings.
2. **`str` as a compiler builtin**: `\"foo\"` now types as the record \`rec { len: u32; data: *u8 }\`. The name `str` resolves as a builtin (alongside `va_list`, `u32`, etc.); no `pub def str` lives in stdlib anymore.

The two literal forms are not interchangeable. `val s: str = \`foo\`` is a type error; `val z: *u8 = \"foo\"` is a type error. Use `::` if you really mean to reinterpret the bits.

## Why

mach has been treating string literals as `*char` since day one, which conflates \"a sequence of bytes mach knows the length of\" with \"a null-terminated pointer for C interop.\" These are different concerns. Splitting them gets us:

- Length-aware mach-internal strings (no walking-to-null in `str_len`)
- Sliced sub-strings without sentinel concerns
- Explicit FFI sites (the `\` literal is the visible cue when bytes cross into C land)

`str` is a complex builtin — the only one. Justified because string literals are syntax that must produce a typed value, and the value is record-shaped. This parallels how integer / float literals already require built-in types to land into.

## Changes

### Token / Lexer
- `TOKEN_LIT_ZSTR` enum variant + display name
- `lexer_parse_lit_zstr` and `lexer_eval_lit_zstr` (mirrors of the string variants with `` \\\` ``-aware escape handling)
- Dispatch on `` ` `` in `lexer_next_token`

### Parser
- `case TOKEN_LIT_ZSTR` builds an `AST_EXPR_LIT` with `lit_expr.kind = TOKEN_LIT_ZSTR`

### AST
- `lit_expr` handling extended for the new kind in `dnit`, `clone`, and both printers

### Type system
- `type_get_builtin_str()` — returns a singleton `rec { len: u32; data: *u8 }` (alongside existing `type_get_builtin_va_list`)

### Sema
- `LIT_STRING` resolves to `type_get_builtin_str()`
- `LIT_ZSTR` resolves to `*u8`
- Type-name lookup recognizes `str` as a builtin (mirrors `va_list`)
- Cross-form assignments produce \"type mismatch\" errors

### Lowering (MASM)
- `LIT_STRING` in expression context: emits a 16-byte record constant in `.rodata` (`u32` len + 4-byte pad + `*u8` data with reloc to the bytes label) and returns the record's address (aggregate-by-pointer convention)
- `LIT_STRING` in data context: emits the record fields inline with the data field relocated
- `LIT_ZSTR` continues to emit a bare pointer in both contexts
- Both forms still null-terminate the underlying bytes so taking `.data` of a literal-derived str gives a usable C pointer

## Test plan

- [x] `make` builds clean
- [x] Sanity programs:
  - `val z: *u8 = \`hello\`;` compiles
  - `val s: str = \"hello\"; ret s.len::i32;` compiles and produces a valid object
  - `val bad: str = \`...\`;` rejected
  - `val bad: *u8 = \"...\";` rejected
- [x] mach-std (PR octalide/mach-std#181) builds clean against this compiler