### PR TITLE
docs: reframe README as cold-start bootstrap hatch only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,35 @@
 mach-boot
 =========
 
-Bootstrap compiler for [mach](https://github.com/octalide/mach), written in C.
+`cmach` is a minimal bootstrap compiler for [mach](https://github.com/octalide/mach), written in C.
 
-This is the first stage of the mach self-hosting pipeline. It compiles the mach source code into an intermediate compiler, which then compiles itself into the final self-hosted compiler.
+It exists for one purpose: producing a working mach compiler from absolute scratch, on a machine where no mach release binary is available. This is the cold-start seed of the toolchain — **not** part of the normal mach build.
 
-## Building
+## When you need this
+
+Normally you do not. mach self-seeds from its own releases: you fetch a released `mach` binary and run `mach build .`. `cmach` is no longer a build input for [octalide/mach](https://github.com/octalide/mach), and that repo no longer ships a Makefile.
+
+Reach for `cmach` only when there is no usable mach release to bootstrap from — a brand-new platform, a fresh port, or recovering the toolchain from C source alone. In that situation `cmach` compiles the mach sources into a first working compiler, which then takes over.
+
+## Building cmach
 
 Prerequisites: clang (or gcc with C23 support), make.
 
 ```bash
-make
-```
-
-Produces `out/bin/cmach`.
-
-## Installing
-
-```bash
+make                               # produces out/bin/cmach
 make install                       # installs to /usr/local/bin/cmach
 make install PREFIX=/opt/mach      # custom prefix
 ```
 
-## Usage
+## Cold-start seeding
 
-cmach is not meant to be used directly. It is acquired automatically by the [mach](https://github.com/octalide/mach) build system. To build mach from source:
-
-```bash
-git clone https://github.com/octalide/mach
-cd mach
-make
-```
-
-If you have cmach installed or built locally, you can point the mach build at it:
+With `cmach` built, point it at a mach project (a directory containing `mach.toml`) to produce a working binary:
 
 ```bash
-CMACH=/path/to/cmach make
+cmach build .
 ```
+
+Use the resulting binary as your `mach` toolchain; from there the standard `mach build .` flow takes over and `cmach` is no longer needed.
 
 ## License
 


### PR DESCRIPTION
Refreshes the README so the repo reads as the cold-start bootstrap hatch the maintainer decided to keep — not part of the normal mach build.

cmach is no longer a build input for octalide/mach: the Makefile was removed and the build is now `mach build .` from a released binary.

Changes:
- Remove the stale `git clone mach && cd mach && make` flow and the `CMACH=… make` auto-download hook.
- State plainly that cmach is a from-absolute-scratch cold-start seed, used only when no mach release is available — not part of the normal build.
- Add a "When you need this" section and a cold-start seeding example (`cmach build .`).
- Keep the build/install instructions for cmach itself (Makefile is unchanged).

Closes #64