### PR TITLE
ci: bump GitHub Actions to Node 24-ready versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install clang
         run: sudo apt-get update && sudo apt-get install -y clang

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install clang
         run: sudo apt-get update && sudo apt-get install -y clang
@@ -24,7 +24,7 @@ jobs:
         run: strip out/bin/cmach
 
       - name: Upload release binary
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: out/bin/cmach
           body: |


### PR DESCRIPTION
Mechanical version bumps per #66, ahead of GitHub's forced Node 24 default on 2026-06-16.

Closes #66